### PR TITLE
TECH-596: Add cucumber test for POST /update-beneficiary-details

### DIFF
--- a/examples/mock/mockoon-paymentsbbvoucher.json
+++ b/examples/mock/mockoon-paymentsbbvoucher.json
@@ -1524,6 +1524,95 @@
       "type": "http"
     },
     {
+      "uuid": "06ed02a6-54a9-4f28-b277-30cb02088981",
+      "type": "http",
+      "documentation": "Update beneficiary details",
+      "method": "post",
+      "endpoint": "update-beneficiary-details",
+      "responses": [
+        {
+          "uuid": "17325161-8b34-4ef3-84a6-dce5986a7c8c",
+          "body": "{\n  \"ResponseCode\": \"00\",\n  \"ResponseDescription\": \"Successfully updated beneficiary details\",\n  \"RequestID\": \"{{bodyRaw 'RequestID'}}\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Successfully updated beneficiary details",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "body",
+              "modifier": "RequestID",
+              "value": "",
+              "invert": true,
+              "operator": "null"
+            },
+            {
+              "target": "body",
+              "modifier": "RequestID",
+              "value": "^\\w{12}$",
+              "invert": false,
+              "operator": "regex"
+            },
+            {
+              "target": "body",
+              "modifier": "SourceBBID",
+              "value": "",
+              "invert": true,
+              "operator": "null"
+            },
+            {
+              "target": "body",
+              "modifier": "SourceBBID",
+              "value": "^\\w{12}$",
+              "invert": false,
+              "operator": "regex"
+            },
+            {
+              "target": "body",
+              "modifier": "Beneficiaries",
+              "value": "",
+              "invert": true,
+              "operator": "null"
+            },
+            {
+              "target": "body",
+              "modifier": "Beneficiaries.0.PayeeFunctionalID",
+              "value": "^\\w{20}$",
+              "invert": false,
+              "operator": "regex"
+            }
+          ],
+          "rulesOperator": "AND",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false
+        },
+        {
+          "uuid": "e8bacc91-936e-4709-a677-a75916f797ca",
+          "body": "{\n  \"ResponseCode\": \"01\",\n  \"ResponseDescription\": \"Error\",\n  \"RequestID\": \"{{bodyRaw 'RequestID'}}\"\n}",
+          "latency": 0,
+          "statusCode": 400,
+          "label": "Unable to update beneficiary details",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true
+        }
+      ],
+      "enabled": true,
+      "responseMode": null,
+      "type": "http"
+    },
+    {
       "uuid": "a5a1aab6-080f-4957-af6c-d7f99805126e",
       "type": "http",
       "documentation": "This API is to be exposed by the Payments BB. It will be called by the Source BB to handover a batch of credit instructions to be processed.",

--- a/examples/mock/mockoon-paymentsbbvoucher.json
+++ b/examples/mock/mockoon-paymentsbbvoucher.json
@@ -1532,10 +1532,10 @@
       "responses": [
         {
           "uuid": "17325161-8b34-4ef3-84a6-dce5986a7c8c",
-          "body": "{\n  \"ResponseCode\": \"00\",\n  \"ResponseDescription\": \"Successfully updated beneficiary details\",\n  \"RequestID\": \"{{bodyRaw 'RequestID'}}\"\n}",
+          "body": "{\n  \"ResponseCode\": \"00\",\n  \"ResponseDescription\": \"Request successfully acknowledged by Pay-BB\",\n  \"RequestID\": \"{{bodyRaw 'RequestID'}}\"\n}",
           "latency": 0,
           "statusCode": 200,
-          "label": "Successfully updated beneficiary details",
+          "label": "Request successfully acknowledged by Pay-BB",
           "headers": [],
           "bodyType": "INLINE",
           "filePath": "",
@@ -1592,10 +1592,10 @@
         },
         {
           "uuid": "e8bacc91-936e-4709-a677-a75916f797ca",
-          "body": "{\n  \"ResponseCode\": \"01\",\n  \"ResponseDescription\": \"Error\",\n  \"RequestID\": \"{{bodyRaw 'RequestID'}}\"\n}",
+          "body": "{\n  \"ResponseCode\": \"01\",\n  \"ResponseDescription\": \"Request not acknowledged by Pay-BB\",\n  \"RequestID\": \"{{bodyRaw 'RequestID'}}\"\n}",
           "latency": 0,
           "statusCode": 400,
-          "label": "Unable to update beneficiary details",
+          "label": "Request not acknowledged by Pay-BB",
           "headers": [],
           "bodyType": "INLINE",
           "filePath": "",

--- a/test/openAPI/features/g2p_update_beneficiary_details.feature
+++ b/test/openAPI/features/g2p_update_beneficiary_details.feature
@@ -1,0 +1,109 @@
+@method=POST @endpoint=/update-beneficiary-details
+Feature: Update beneficiary details
+
+This is the API that is called by the Information Mediator BB when the Registration BB
+in turn calls its API for registering beneficiaries into the ID Mapper of the Payments BB.
+
+    @smoke @unit @potitive
+    Scenario: Succesfully updated beneficiary details smoke type test
+        Given Information Mediator BB wants to update beneficiary details
+        When POST request to update beneficiary details with given "stringstring" as RequestID, "stringstring" as SourceBBID and "stringstringstringst" as PayeeFunctionalID is sent
+        Then The response from the /update-beneficiary-details is received
+        And The /update-beneficiary-details response should be returned in a timely manner 15000ms
+        And The /update-beneficiary-details response should have status 200
+        And The /update-beneficiary-details response should have content-type: application/json header
+        And The /update-beneficiary-details response should match json schema
+
+    #todo add multiple updates in one query
+
+    @unit @potitive
+    Scenario: Succesfully updated beneficiary details using not obligatory fields in the request payload
+        Given Information Mediator BB wants to update beneficiary details
+        When POST request to update beneficiary details with given "stringstring" as RequestID, "stringstring" as SourceBBID, "stringstringstringst" as PayeeFunctionalID, "01" as PaymentModality and "string" as FinancialAddress is sent
+        Then The response from the /update-beneficiary-details is received
+        And The /update-beneficiary-details response should be returned in a timely manner 15000ms
+        And The /update-beneficiary-details response should have status 200
+        And The /update-beneficiary-details response should have content-type: application/json header
+        And The /update-beneficiary-details response should match json schema
+        And The /update-beneficiary-details response ResponseCode field should be "00"
+        And The /update-beneficiary-details response RequestID field should be "stringstring"
+
+    # @unit @negative
+    # Scenario: Unable to update beneficiary details because of empty payload in the request
+    #     Given Information Mediator BB wants to update beneficiary details
+    #     When POST request to update beneficiary details is sent without payload
+    #     Then The response from the /update-beneficiary-details is received
+    #     And The /update-beneficiary-details response should be returned in a timely manner 15000ms
+    #     And The /update-beneficiary-details response should have status 400
+    #     And The /update-beneficiary-details response should have content-type: application/json header
+    #     And The /update-beneficiary-details response should match json schema
+    #     And The /update-beneficiary-details response ResponseCode field should be "01"
+
+
+    # @unit @negative
+    # Scenario: Unable to update beneficiary details because of missing required RequestID in the payload
+    #     Given Information Mediator BB wants to update beneficiary details
+    #     When POST request to update beneficiary details with given "stringstring" as SourceBBID and "stringstringstringst" as PayeeFunctionalID is sent
+    #     Then The response from the /update-beneficiary-details is received
+    #     And The /update-beneficiary-details response should be returned in a timely manner 15000ms
+    #     And The /update-beneficiary-details response should have status 400
+    #     And The /update-beneficiary-details response should have content-type: application/json header
+    #     And The /update-beneficiary-details response should match json schema
+    #     And The /update-beneficiary-details response ResponseCode field should be "01"
+
+    @unit @negative
+    Scenario: Unable to update beneficiary details because of missing required SourceBBID in the payload
+        Given Information Mediator BB wants to update beneficiary details
+        When POST request to update beneficiary details with given "stringstring" as RequestID and "stringstringstringst" as PayeeFunctionalID is sent
+        Then The response from the /update-beneficiary-details is received
+        And The /update-beneficiary-details response should be returned in a timely manner 15000ms
+        And The /update-beneficiary-details response should have status 400
+        And The /update-beneficiary-details response should have content-type: application/json header
+        And The /update-beneficiary-details response should match json schema
+        And The /update-beneficiary-details response ResponseCode field should be "01"
+        And The /update-beneficiary-details response RequestID field should be "stringstring"
+
+    @unit @negative
+    Scenario: Unable to update beneficiary details because of missing required PayeeFunctionalID in the payload
+        Given Information Mediator BB wants to update beneficiary details
+        When POST request to update beneficiary details with given "stringstring" as RequestID and "stringstring" as SourceBBID is sent
+        Then The response from the /update-beneficiary-details is received
+        And The /update-beneficiary-details response should be returned in a timely manner 15000ms
+        And The /update-beneficiary-details response should have status 400
+        And The /update-beneficiary-details response should have content-type: application/json header
+        And The /update-beneficiary-details response should match json schema
+        And The /update-beneficiary-details response ResponseCode field should be "01"
+        And The /update-beneficiary-details response RequestID field should be "stringstring"
+
+    # @unit @negative
+    # Scenario: Unable to update beneficiary details because of invalid RequestID value in the payload
+    #     Given Information Mediator BB wants to update beneficiary details
+    #     When POST request to update beneficiary details with given "invalid" as RequestID, "stringstring" as SourceBBID and "stringstringstringst" as PayeeFunctionalID is sent
+    #     Then The response from the /update-beneficiary-details is received
+    #     And The /update-beneficiary-details response should be returned in a timely manner 15000ms
+    #     And The /update-beneficiary-details response should have status 400
+    #     And The /update-beneficiary-details response should have content-type: application/json header
+    #     And The /update-beneficiary-details response should match json schema
+    #     And The /update-beneficiary-details response ResponseCode field should be "01"
+
+    @unit @negative
+    Scenario: Unable to update beneficiary details because of invalid SourceBBID value in the payload
+        Given Information Mediator BB wants to update beneficiary details
+        When POST request to update beneficiary details with given "stringstring" as RequestID, "invalid" as SourceBBID and "stringstringstringst" as PayeeFunctionalID is sent
+        Then The response from the /update-beneficiary-details is received
+        And The /update-beneficiary-details response should be returned in a timely manner 15000ms
+        And The /update-beneficiary-details response should have status 400
+        And The /update-beneficiary-details response should have content-type: application/json header
+        And The /update-beneficiary-details response should match json schema
+        And The /update-beneficiary-details response ResponseCode field should be "01"
+
+    @unit @negative
+    Scenario: Unable to update beneficiary details because of invalid PayeeFunctionalID value in the payload
+        Given Information Mediator BB wants to update beneficiary details
+        When POST request to update beneficiary details with given "stringstring" as RequestID, "stringstring" as SourceBBID and "invalid" as PayeeFunctionalID is sent
+        Then The response from the /update-beneficiary-details is received
+        And The /update-beneficiary-details response should be returned in a timely manner 15000ms
+        And The /update-beneficiary-details response should have status 400
+        And The /update-beneficiary-details response should have content-type: application/json header
+        And The /update-beneficiary-details response should match json schema
+        And The /update-beneficiary-details response ResponseCode field should be "01"

--- a/test/openAPI/features/g2p_update_beneficiary_details.feature
+++ b/test/openAPI/features/g2p_update_beneficiary_details.feature
@@ -4,7 +4,7 @@ Feature: Update beneficiary details
 This is the API that is called by the Information Mediator BB when the Registration BB
 in turn calls its API for registering beneficiaries into the ID Mapper of the Payments BB.
 
-    @smoke @unit @potitive
+    @smoke @unit @positive
     Scenario: Succesfully updated beneficiary details smoke type test
         Given Information Mediator BB wants to update beneficiary details
         When POST request to update beneficiary details with given "stringstring" as RequestID, "stringstring" as SourceBBID and "stringstringstringst" as PayeeFunctionalID is sent
@@ -14,9 +14,7 @@ in turn calls its API for registering beneficiaries into the ID Mapper of the Pa
         And The /update-beneficiary-details response should have content-type: application/json header
         And The /update-beneficiary-details response should match json schema
 
-    #todo add multiple updates in one query
-
-    @unit @potitive
+    @unit @positive
     Scenario: Succesfully updated beneficiary details using not obligatory fields in the request payload
         Given Information Mediator BB wants to update beneficiary details
         When POST request to update beneficiary details with given "stringstring" as RequestID, "stringstring" as SourceBBID, "stringstringstringst" as PayeeFunctionalID, "01" as PaymentModality and "string" as FinancialAddress is sent
@@ -27,29 +25,6 @@ in turn calls its API for registering beneficiaries into the ID Mapper of the Pa
         And The /update-beneficiary-details response should match json schema
         And The /update-beneficiary-details response ResponseCode field should be "00"
         And The /update-beneficiary-details response RequestID field should be "stringstring"
-
-    # @unit @negative
-    # Scenario: Unable to update beneficiary details because of empty payload in the request
-    #     Given Information Mediator BB wants to update beneficiary details
-    #     When POST request to update beneficiary details is sent without payload
-    #     Then The response from the /update-beneficiary-details is received
-    #     And The /update-beneficiary-details response should be returned in a timely manner 15000ms
-    #     And The /update-beneficiary-details response should have status 400
-    #     And The /update-beneficiary-details response should have content-type: application/json header
-    #     And The /update-beneficiary-details response should match json schema
-    #     And The /update-beneficiary-details response ResponseCode field should be "01"
-
-
-    # @unit @negative
-    # Scenario: Unable to update beneficiary details because of missing required RequestID in the payload
-    #     Given Information Mediator BB wants to update beneficiary details
-    #     When POST request to update beneficiary details with given "stringstring" as SourceBBID and "stringstringstringst" as PayeeFunctionalID is sent
-    #     Then The response from the /update-beneficiary-details is received
-    #     And The /update-beneficiary-details response should be returned in a timely manner 15000ms
-    #     And The /update-beneficiary-details response should have status 400
-    #     And The /update-beneficiary-details response should have content-type: application/json header
-    #     And The /update-beneficiary-details response should match json schema
-    #     And The /update-beneficiary-details response ResponseCode field should be "01"
 
     @unit @negative
     Scenario: Unable to update beneficiary details because of missing required SourceBBID in the payload
@@ -75,17 +50,6 @@ in turn calls its API for registering beneficiaries into the ID Mapper of the Pa
         And The /update-beneficiary-details response ResponseCode field should be "01"
         And The /update-beneficiary-details response RequestID field should be "stringstring"
 
-    # @unit @negative
-    # Scenario: Unable to update beneficiary details because of invalid RequestID value in the payload
-    #     Given Information Mediator BB wants to update beneficiary details
-    #     When POST request to update beneficiary details with given "invalid" as RequestID, "stringstring" as SourceBBID and "stringstringstringst" as PayeeFunctionalID is sent
-    #     Then The response from the /update-beneficiary-details is received
-    #     And The /update-beneficiary-details response should be returned in a timely manner 15000ms
-    #     And The /update-beneficiary-details response should have status 400
-    #     And The /update-beneficiary-details response should have content-type: application/json header
-    #     And The /update-beneficiary-details response should match json schema
-    #     And The /update-beneficiary-details response ResponseCode field should be "01"
-
     @unit @negative
     Scenario: Unable to update beneficiary details because of invalid SourceBBID value in the payload
         Given Information Mediator BB wants to update beneficiary details
@@ -96,6 +60,7 @@ in turn calls its API for registering beneficiaries into the ID Mapper of the Pa
         And The /update-beneficiary-details response should have content-type: application/json header
         And The /update-beneficiary-details response should match json schema
         And The /update-beneficiary-details response ResponseCode field should be "01"
+        And The /update-beneficiary-details response RequestID field should be "stringstring"
 
     @unit @negative
     Scenario: Unable to update beneficiary details because of invalid PayeeFunctionalID value in the payload
@@ -107,3 +72,4 @@ in turn calls its API for registering beneficiaries into the ID Mapper of the Pa
         And The /update-beneficiary-details response should have content-type: application/json header
         And The /update-beneficiary-details response should match json schema
         And The /update-beneficiary-details response ResponseCode field should be "01"
+        And The /update-beneficiary-details response RequestID field should be "stringstring"

--- a/test/openAPI/features/support/g2p_update_beneficiary_details.js
+++ b/test/openAPI/features/support/g2p_update_beneficiary_details.js
@@ -122,34 +122,6 @@ Then(
       .to.be.equals(requestID)
 );
 
-// Scenario: Unable to update beneficiary details because of empty payload in the request
-// Others Given, When, Then are written in the aforementioned example
-When(
-  /^POST request to update beneficiary details is sent without payload$/,
-  () =>
-    specUpdateBeneficiaryDetails
-      .post(baseUrl)
-      .withHeaders(acceptHeader.key, acceptHeader.value)
-);
-
-// Scenario: Unable to update beneficiary details because of missing required RequestID in the payload
-// Others Given, When, Then are written in the aforementioned example
-When(
-  /^POST request to update beneficiary details with given "([^"]*)" as SourceBBID and "([^"]*)" as PayeeFunctionalID is sent$/,
-  (sourceBBID, payeeFunctionalID) =>
-    specUpdateBeneficiaryDetails
-      .post(baseUrl)
-      .withHeaders(acceptHeader.key, acceptHeader.value)
-      .withJson({
-        SourceBBID: sourceBBID,
-        Beneficiaries: [
-          {
-            PayeeFunctionalID: payeeFunctionalID,
-          },
-        ],
-      })
-);
-
 // Scenario: Unable to update beneficiary details because of missing required SourceBBID in the payload
 // Others Given, When, Then are written in the aforementioned example
 When(
@@ -182,6 +154,12 @@ When(
         Beneficiaries: [],
       })
 );
+
+// Scenario: Unable to update beneficiary details because of invalid SourceBBID value in the payload
+// Given, When, Then are written in the aforementioned example
+
+// Scenario: Unable to update beneficiary details because of invalid PayeeFunctionalID value in the payload
+// Given, When, Then are written in the aforementioned example
 
 After(endpointTag, () => {
   specUpdateBeneficiaryDetails.end();

--- a/test/openAPI/features/support/g2p_update_beneficiary_details.js
+++ b/test/openAPI/features/support/g2p_update_beneficiary_details.js
@@ -1,0 +1,188 @@
+const chai = require('chai');
+const { spec } = require('pactum');
+const { Given, When, Then, Before, After } = require('@cucumber/cucumber');
+const {
+  localhost,
+  defaultExpectedResponseTime,
+  contentTypeHeader,
+  acceptHeader,
+  updateBeneficiaryDetailsEndpoint,
+  g2pResponseSchema,
+} = require('./helpers/helpers');
+
+chai.use(require('chai-json-schema'));
+
+const baseUrl = localhost + updateBeneficiaryDetailsEndpoint;
+const endpointTag = { tags: `@endpoint=/${updateBeneficiaryDetailsEndpoint}` };
+
+Before(endpointTag, () => {
+  specUpdateBeneficiaryDetails = spec();
+});
+
+// Scenario: Succesfully updated beneficiary details smoke type test
+Given(
+  /^Information Mediator BB wants to update beneficiary details$/,
+  () => 'Information Mediator BB wants to update beneficiary details'
+);
+
+When(
+  /^POST request to update beneficiary details with given "([^"]*)" as RequestID, "([^"]*)" as SourceBBID and "([^"]*)" as PayeeFunctionalID is sent$/,
+  (requestID, sourceBBID, payeeFunctionalID) =>
+    specUpdateBeneficiaryDetails
+      .post(baseUrl)
+      .withHeaders(acceptHeader.key, acceptHeader.value)
+      .withJson({
+        RequestID: requestID,
+        SourceBBID: sourceBBID,
+        Beneficiaries: [{ PayeeFunctionalID: payeeFunctionalID }],
+      })
+);
+
+Then(
+  /^The response from the \/update\-beneficiary\-details is received$/,
+  async () => await specUpdateBeneficiaryDetails.toss()
+);
+
+Then(
+  /^The \/update\-beneficiary\-details response should be returned in a timely manner 15000ms$/,
+  () =>
+    specUpdateBeneficiaryDetails
+      .response()
+      .to.have.responseTimeLessThan(defaultExpectedResponseTime)
+);
+
+Then(
+  /^The \/update\-beneficiary\-details response should have status (\d+)$/,
+  status => {
+    specUpdateBeneficiaryDetails.response().to.have.status(status);
+  }
+);
+
+Then(
+  /^The \/update\-beneficiary\-details response should have content\-type: application\/json header$/,
+  () =>
+    specUpdateBeneficiaryDetails
+      .response()
+      .should.have.header(contentTypeHeader.key, contentTypeHeader.value)
+);
+
+Then(
+  /^The \/update\-beneficiary\-details response should match json schema$/,
+  () =>
+    chai
+      .expect(specUpdateBeneficiaryDetails._response.json)
+      .to.be.jsonSchema(g2pResponseSchema)
+);
+
+// Scenario: Succesfully updated beneficiary details using not obligatory fields in the request payload
+// Others Given, When, Then are written in the aforementioned example
+When(
+  /^POST request to update beneficiary details with given "([^"]*)" as RequestID, "([^"]*)" as SourceBBID, "([^"]*)" as PayeeFunctionalID, "([^"]*)" as PaymentModality and "([^"]*)" as FinancialAddress is sent$/,
+  (
+    requestID,
+    sourceBBID,
+    payeeFunctionalID,
+    paymentModality,
+    financialAddress
+  ) =>
+    specUpdateBeneficiaryDetails
+      .post(baseUrl)
+      .withHeaders(acceptHeader.key, acceptHeader.value)
+      .withJson({
+        RequestID: requestID,
+        SourceBBID: sourceBBID,
+        Beneficiaries: [
+          {
+            PayeeFunctionalID: payeeFunctionalID,
+            PaymentModality: paymentModality,
+            FinancialAddress: financialAddress,
+          },
+        ],
+      })
+);
+
+Then(
+  /^The \/update\-beneficiary\-details response ResponseCode field should be "([^"]*)"$/,
+  responseCode =>
+    chai
+      .expect(
+        specUpdateBeneficiaryDetails.response().to.have.response.json
+          .ResponseCode
+      )
+      .to.be.equals(responseCode)
+);
+
+Then(
+  /^The \/update\-beneficiary\-details response RequestID field should be "([^"]*)"$/,
+  requestID =>
+    chai
+      .expect(
+        specUpdateBeneficiaryDetails.response().to.have.response.json.RequestID
+      )
+      .to.be.equals(requestID)
+);
+
+// Scenario: Unable to update beneficiary details because of empty payload in the request
+// Others Given, When, Then are written in the aforementioned example
+When(
+  /^POST request to update beneficiary details is sent without payload$/,
+  () =>
+    specUpdateBeneficiaryDetails
+      .post(baseUrl)
+      .withHeaders(acceptHeader.key, acceptHeader.value)
+);
+
+// Scenario: Unable to update beneficiary details because of missing required RequestID in the payload
+// Others Given, When, Then are written in the aforementioned example
+When(
+  /^POST request to update beneficiary details with given "([^"]*)" as SourceBBID and "([^"]*)" as PayeeFunctionalID is sent$/,
+  (sourceBBID, payeeFunctionalID) =>
+    specUpdateBeneficiaryDetails
+      .post(baseUrl)
+      .withHeaders(acceptHeader.key, acceptHeader.value)
+      .withJson({
+        SourceBBID: sourceBBID,
+        Beneficiaries: [
+          {
+            PayeeFunctionalID: payeeFunctionalID,
+          },
+        ],
+      })
+);
+
+// Scenario: Unable to update beneficiary details because of missing required SourceBBID in the payload
+// Others Given, When, Then are written in the aforementioned example
+When(
+  /^POST request to update beneficiary details with given "([^"]*)" as RequestID and "([^"]*)" as PayeeFunctionalID is sent$/,
+  (requestID, payeeFunctionalID) =>
+    specUpdateBeneficiaryDetails
+      .post(baseUrl)
+      .withHeaders(acceptHeader.key, acceptHeader.value)
+      .withJson({
+        RequestID: requestID,
+        Beneficiaries: [
+          {
+            PayeeFunctionalID: payeeFunctionalID,
+          },
+        ],
+      })
+);
+
+// Scenario: Unable to update beneficiary details because of missing required PayeeFunctionalID in the payload
+// Others Given, When, Then are written in the aforementioned example
+When(
+  /^POST request to update beneficiary details with given "([^"]*)" as RequestID and "([^"]*)" as SourceBBID is sent$/,
+  (requestID, sourceBBID) =>
+    specUpdateBeneficiaryDetails
+      .post(baseUrl)
+      .withHeaders(acceptHeader.key, acceptHeader.value)
+      .withJson({
+        RequestID: requestID,
+        SourceBBID: sourceBBID,
+        Beneficiaries: [],
+      })
+);
+
+After(endpointTag, () => {
+  specUpdateBeneficiaryDetails.end();
+});

--- a/test/openAPI/features/support/helpers/helpers.js
+++ b/test/openAPI/features/support/helpers/helpers.js
@@ -11,6 +11,7 @@ module.exports = {
   },
   bulkPaymentEndpoint: 'bulk-payment',
   registerBeneficiaryEndpoint: 'register-beneficiary',
+  updateBeneficiaryDetailsEndpoint: 'update-beneficiary-details',
   g2pResponseSchema: {
     type: 'object',
     properties: {


### PR DESCRIPTION
Added gherkin scenarios, mocks and Cucumber tests for /update-beneficiary-details.

## Description
Add cucumber test for Payment BB - Payment G2P - POST /update-beneficiary-details.
Make sure tests contain
- smoke tests
- sanity performance tests
- no hard-coded data
- header tests
- etc. that are described in https://govstack-global.atlassian.net/wiki/spaces/GH/pages/157712385/Gherkin+file+template
API spec: https://github.com/GovStackWorkingGroup/bb-payments/blob/main/api/UpdateBeneficiary.yaml
 
Acceptance criteria:
    test is updated
    test match with accepted template

TICKET: https://govstack-global.atlassian.net/browse/TECH-596